### PR TITLE
fix: Cannot kill wandering armor stand with low food level in creative mode

### DIFF
--- a/26.1.2/src/main/kotlin/com/bleudev/nine_lifes/custom/entity/WanderingArmorStand.kt
+++ b/26.1.2/src/main/kotlin/com/bleudev/nine_lifes/custom/entity/WanderingArmorStand.kt
@@ -36,7 +36,7 @@ class WanderingArmorStand(entityType: EntityType<out PathfinderMob>, level: Leve
 
     private fun canKill(damageSource: DamageSource) = damageSource.`is`(DamageTypes.GENERIC_KILL)
     private fun canTryKill(player: ServerPlayer): Boolean {
-        return player.foodData.foodLevel >= 5f
+        return !player.gameMode().isSurvival || player.foodData.foodLevel >= 5f
     }
     private fun triedKillReact(player: ServerPlayer) {
         if (!player.gameMode().isSurvival) return

--- a/26.2/src/main/kotlin/com/bleudev/nine_lifes/custom/entity/WanderingArmorStand.kt
+++ b/26.2/src/main/kotlin/com/bleudev/nine_lifes/custom/entity/WanderingArmorStand.kt
@@ -36,7 +36,7 @@ class WanderingArmorStand(entityType: EntityType<out PathfinderMob>, level: Leve
 
     private fun canKill(damageSource: DamageSource) = damageSource.`is`(DamageTypes.GENERIC_KILL)
     private fun canTryKill(player: ServerPlayer): Boolean {
-        return player.foodData.foodLevel >= 5f
+        return !player.gameMode().isSurvival || player.foodData.foodLevel >= 5f
     }
     private fun triedKillReact(player: ServerPlayer) {
         if (!player.gameMode().isSurvival) return

--- a/26.3/src/main/kotlin/com/bleudev/nine_lifes/custom/entity/WanderingArmorStand.kt
+++ b/26.3/src/main/kotlin/com/bleudev/nine_lifes/custom/entity/WanderingArmorStand.kt
@@ -36,7 +36,7 @@ class WanderingArmorStand(entityType: EntityType<out PathfinderMob>, level: Leve
 
     private fun canKill(damageSource: DamageSource) = damageSource.`is`(DamageTypes.GENERIC_KILL)
     private fun canTryKill(player: ServerPlayer): Boolean {
-        return player.foodData.foodLevel >= 5f
+        return !player.gameMode().isSurvival || player.foodData.foodLevel >= 5f
     }
     private fun triedKillReact(player: ServerPlayer) {
         if (!player.gameMode().isSurvival) return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 ### Fixes
 
 - Untranslated sound subtitles (bleudev [#125](https://github.com/bleudev/nine_lifes/pull/125))
+- Cannot kill wandering armor stand with low food level in creative mode (bleudev [#126](https://github.com/bleudev/nine_lifes/pull/126))


### PR DESCRIPTION
fixes #123 